### PR TITLE
Fix behaviour inheritance

### DIFF
--- a/TouchTracking.MAUI/Platforms/Android/TouchTrackingBehavior.Droid.cs
+++ b/TouchTracking.MAUI/Platforms/Android/TouchTrackingBehavior.Droid.cs
@@ -3,7 +3,7 @@ using TouchTracking.Droid;
 
 namespace TouchTracking;
 
-public partial class TouchTrackingBehavior : PlatformBehavior<View, Android.Views.View>
+public partial class TouchTrackingBehavior
 {
     private TouchHandler _touchHandler;
     private Android.Views.View _view;

--- a/TouchTracking.MAUI/Platforms/MacCatalyst/TouchTrackingBehavior.MacCat.cs
+++ b/TouchTracking.MAUI/Platforms/MacCatalyst/TouchTrackingBehavior.MacCat.cs
@@ -3,7 +3,7 @@ using UIKit;
 
 namespace TouchTracking;
 
-public partial class TouchTrackingBehavior : PlatformBehavior<View, UIView>
+public partial class TouchTrackingBehavior
 {
 	private TouchHandler? _touchHandler;
 

--- a/TouchTracking.MAUI/Platforms/Windows/TouchTrackingBehavior.Win.cs
+++ b/TouchTracking.MAUI/Platforms/Windows/TouchTrackingBehavior.Win.cs
@@ -3,7 +3,7 @@ using TouchTracking.WinUI;
 
 namespace TouchTracking;
 
-public partial class TouchTrackingBehavior : PlatformBehavior<View, FrameworkElement>
+public partial class TouchTrackingBehavior
 {
     private TouchHandler? _touchHandler;
 

--- a/TouchTracking.MAUI/Platforms/iOS/TouchTrackingBehavior.iOS.cs
+++ b/TouchTracking.MAUI/Platforms/iOS/TouchTrackingBehavior.iOS.cs
@@ -3,7 +3,7 @@ using UIKit;
 
 namespace TouchTracking;
 
-public partial class TouchTrackingBehavior : PlatformBehavior<View, UIView>
+public partial class TouchTrackingBehavior
 {
     private TouchHandler? _touchHandler;
 

--- a/TouchTracking.MAUI/TouchTrackingBehavior.cs
+++ b/TouchTracking.MAUI/TouchTrackingBehavior.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace TouchTracking;
 
-public partial class TouchTrackingBehavior
+public partial class TouchTrackingBehavior : PlatformBehavior<View>
 {
 	public event TouchActionEventHandler TouchAction;
 


### PR DESCRIPTION
This should fix issue https://github.com/nor0x/TouchTracking.MAUI/issues/2 by having the cross platform behaviour implement `PlatformBehavior<View>`. Also renamed the cross platform behaviour for consistency.